### PR TITLE
Debug: Add verbose logging to deleteClient handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -157,9 +157,24 @@ io.on('connection', async (socket) => {
     }
   });
 
-  socket.on('deleteClient', async ({ id }) => {
+  socket.on('deleteClient', async (payload) => {
+    console.log('--- DEBUG: deleteClient event received ---');
+    console.log('Raw payload:', payload);
+    console.log('Type of payload:', typeof payload);
+
+    // Let's manually destructure to be safe
+    const id = payload ? payload.id : undefined;
+
+    console.log('Extracted ID:', id);
+    console.log('Type of ID:', typeof id);
+    console.log('User is privileged:', isPrivileged(socket.user));
+    console.log('Condition check (isPrivileged && id):', isPrivileged(socket.user) && !!id);
+
     if (isPrivileged(socket.user) && id) {
+      console.log('--- DEBUG: Proceeding with delete operation ---');
       await handleDatabaseWrite(socket, db.deleteClient, id);
+    } else {
+      console.log('--- DEBUG: Delete operation skipped due to failed checks ---');
     }
   });
 


### PR DESCRIPTION
This commit adds extensive, detailed logging to the `deleteClient` socket event handler on the server. This is a temporary debugging measure to definitively identify the cause of a persistent server crash that occurs during this operation.

The logs will capture the exact payload received from the client, its type, the extracted ID, and the result of the privilege checks before the database operation is attempted. This information is crucial for diagnosing why the database query is failing with a 'no parameter' error despite the presence of guard clauses.