### PR TITLE
feat: Add temporary endpoint for database reset

### DIFF
--- a/database.js
+++ b/database.js
@@ -60,9 +60,24 @@ const initSchema = async () => {
     }
 };
 
+const resetDatabase = async () => {
+  console.log('[DB] Attempting to reset database...');
+  try {
+    await query('DROP SCHEMA public CASCADE; CREATE SCHEMA public;');
+    console.log('[DB] Database reset successful.');
+    // After resetting, we must re-initialize the schema
+    await initSchema();
+    return { success: true, message: 'База данных успешно сброшена и пересоздана.' };
+  } catch (err) {
+    console.error('!!! DATABASE RESET ERROR:', err);
+    return { success: false, message: `Ошибка при сбросе базы данных: ${err.message}` };
+  }
+};
+
 module.exports = {
   // Initialization
   loadDB: initSchema,
+  resetDatabase, // Export the new function
 
   // Data Getters
   getUsers: async () => {

--- a/server.js
+++ b/server.js
@@ -98,6 +98,16 @@ const broadcastUpdates = async () => {
     }
 };
 
+app.get('/reset-db-a1b2c3', async (req, res) => {
+  console.log('!!! Received request to reset database !!!');
+  const result = await db.resetDatabase();
+  if (result.success) {
+    res.status(200).send(`<h1>${result.message}</h1><p>Пожалуйста, перезагрузите страницу входа и попробуйте войти снова с оригинальными учетными данными.</p>`);
+  } else {
+    res.status(500).send(`<h1>${result.message}</h1>`);
+  }
+});
+
 app.post('/login', async (req, res) => {
   const { login, password } = req.body;
   const users = await db.getUsers();


### PR DESCRIPTION
This commit adds a temporary, secret endpoint to `server.js` at `/reset-db-a1b2c3`. This endpoint is designed to be visited once by the user to trigger a full database reset, resolving a persistent state corruption issue.

A corresponding `resetDatabase` function has been added to `database.js` to perform the `DROP SCHEMA`/`CREATE SCHEMA` operation.

This endpoint is intended for immediate use and will be removed in a subsequent commit.