### PR TITLE
fix: Remove temporary DB reset endpoint

### DIFF
--- a/database.js
+++ b/database.js
@@ -60,24 +60,9 @@ const initSchema = async () => {
     }
 };
 
-const resetDatabase = async () => {
-  console.log('[DB] Attempting to reset database...');
-  try {
-    await query('DROP SCHEMA public CASCADE; CREATE SCHEMA public;');
-    console.log('[DB] Database reset successful.');
-    // After resetting, we must re-initialize the schema
-    await initSchema();
-    return { success: true, message: 'База данных успешно сброшена и пересоздана.' };
-  } catch (err) {
-    console.error('!!! DATABASE RESET ERROR:', err);
-    return { success: false, message: `Ошибка при сбросе базы данных: ${err.message}` };
-  }
-};
-
 module.exports = {
   // Initialization
   loadDB: initSchema,
-  resetDatabase, // Export the new function
 
   // Data Getters
   getUsers: async () => {

--- a/server.js
+++ b/server.js
@@ -98,16 +98,6 @@ const broadcastUpdates = async () => {
     }
 };
 
-app.get('/reset-db-a1b2c3', async (req, res) => {
-  console.log('!!! Received request to reset database !!!');
-  const result = await db.resetDatabase();
-  if (result.success) {
-    res.status(200).send(`<h1>${result.message}</h1><p>Пожалуйста, перезагрузите страницу входа и попробуйте войти снова с оригинальными учетными данными.</p>`);
-  } else {
-    res.status(500).send(`<h1>${result.message}</h1>`);
-  }
-});
-
 app.post('/login', async (req, res) => {
   const { login, password } = req.body;
   const users = await db.getUsers();


### PR DESCRIPTION
This commit removes the temporary `/reset-db-a1b2c3` endpoint from `server.js` and the corresponding `resetDatabase` function from `database.js`.

This action is taken after the user has successfully used the endpoint to reset their database state, and is done to ensure the security of the application by removing a potentially destructive endpoint.